### PR TITLE
Delete unused NotepadApp Procfile

### DIFF
--- a/NotepadApp/Procfile
+++ b/NotepadApp/Procfile
@@ -1,1 +1,0 @@
-web: dotnet NotepadApp.dll 


### PR DESCRIPTION
This `Procfile` isn't being used (and the command wouldn't work on Heroku if it was :))